### PR TITLE
fix: tollbar options type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -69,7 +69,7 @@ interface IEditorProps {
             maxSize?: number;
             imageAccept?: string;
         };
-        toolbarOptions?: [][];
+        toolbarOptions?: Array<(string | { [key: string]: string })[]>;
     } & IModules;
     getQuill?: (quill: Quill, uploadedImgsList?: string[]) => void;
     content?: Delta | string;


### PR DESCRIPTION
The current type for toolbar options is `[][]` which means an array filled of empty arrays.